### PR TITLE
fix: upload asset file names are incorrect resulting in build failure

### DIFF
--- a/.github/workflows/create-release-upload-assets.yml
+++ b/.github/workflows/create-release-upload-assets.yml
@@ -34,8 +34,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/snowflakeintegration-linux-x64
-          asset_name: snowflakeintegration-linux-x64
+          asset_path: ./dist/snowflakeintegration-linux
+          asset_name: snowflakeintegration-linux
           asset_content_type: application/octet-stream
       - name: Upload Win Release Asset
         id: upload-win-release-asset
@@ -44,6 +44,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/snowflakeintegration-win-x64.exe
-          asset_name: snowflakeintegration-win-x64.exe
+          asset_path: ./dist/snowflakeintegration-win.exe
+          asset_name: snowflakeintegration-win.exe
           asset_content_type: application/octet-stream

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snowflakeintegration",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snowflakeintegration",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "node-vault": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowflakeintegration",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "newrelic snowflake integration",
   "main": "snowflake.js",
   "bin": "snowflake.js",


### PR DESCRIPTION
## Fixes
* Build release fails because asset names include `-x64` but `pkg` does not append arch when all targets have the same arch