### PR TITLE
fix: set log level for snowflake

### DIFF
--- a/snowflake.js
+++ b/snowflake.js
@@ -72,16 +72,6 @@ function setLogLevel(logLevel) {
     }
 }
 
-function setSnowflakeLogLevel(logLevel) {
-    const validLogLevels = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
-
-    const configuredLogLevel = validLogLevels.includes(logLevel?.toUpperCase()) 
-        ? logLevel.toUpperCase() 
-        : 'ERROR'
-
-    snowflake.configure({ logLevel: config.logLevel, additionalLogToConsole: false })
-}
-
 function revealConfig() {
     // if (config.obfuscationEncodingKey != null && config.obfuscationEncodingKey.toString().length > 0) {
     //     for (const [key, value] of Object.entries(config.connection)) {
@@ -178,7 +168,7 @@ function execute() {
     const parsedOptions = parseOptions(), 
         config = loadNriConfig(parsedOptions)
     
-    setSnowflakeLogLevel(config.logLevel)
+    snowflake.configure({ logLevel: 'ERROR', additionalLogToConsole: false })
     const connection = snowflake.createConnection(config.connection)
 
     connection.connect((err, connection) => {

--- a/snowflake.js
+++ b/snowflake.js
@@ -79,7 +79,7 @@ function setSnowflakeLogLevel(logLevel) {
         ? logLevel.toUpperCase() 
         : 'ERROR'
 
-    snowflake.configure({ logLevel: configuredLogLevel })
+    snowflake.configure({ logLevel: config.logLevel, additionalLogToConsole: false })
 }
 
 function revealConfig() {

--- a/snowflake.js
+++ b/snowflake.js
@@ -72,6 +72,19 @@ function setLogLevel(logLevel) {
     }
 }
 
+function toSnowflakeLogLevel(winstonLogLevel) {
+    const logLevelMapping = {
+        error: 'ERROR',
+        warn: 'WARNING',
+        info: 'INFO',
+        http: 'DEBUG',
+        verbose: 'DEBUG',
+        debug: 'DEBUG',
+        silly: 'TRACE'
+    };
+    return logLevelMapping[winstonLogLevel] || 'OFF';
+}
+
 function revealConfig() {
     // if (config.obfuscationEncodingKey != null && config.obfuscationEncodingKey.toString().length > 0) {
     //     for (const [key, value] of Object.entries(config.connection)) {
@@ -168,7 +181,7 @@ function execute() {
     const parsedOptions = parseOptions(), 
         config = loadNriConfig(parsedOptions)
     
-    snowflake.configure({ logLevel: 'ERROR', additionalLogToConsole: false })
+    snowflake.configure({ logLevel: toSnowflakeLogLevel(config.logLevel), additionalLogToConsole: false })
     const connection = snowflake.createConnection(config.connection)
 
     connection.connect((err, connection) => {

--- a/snowflake.js
+++ b/snowflake.js
@@ -39,6 +39,16 @@ const options = {
         format.simple(),
     )
 
+const LOG_LEVEL_MAPPING = {
+        error: 'ERROR',
+        warn: 'WARNING',
+        info: 'INFO',
+        http: 'DEBUG',
+        verbose: 'DEBUG',
+        debug: 'DEBUG',
+        silly: 'TRACE'
+}
+
 let logger
 
 function usage() {
@@ -73,16 +83,11 @@ function setLogLevel(logLevel) {
 }
 
 function toSnowflakeLogLevel(winstonLogLevel) {
-    const logLevelMapping = {
-        error: 'ERROR',
-        warn: 'WARNING',
-        info: 'INFO',
-        http: 'DEBUG',
-        verbose: 'DEBUG',
-        debug: 'DEBUG',
-        silly: 'TRACE'
-    };
-    return logLevelMapping[winstonLogLevel] || 'OFF';
+    if (!winstonLogLevel) {
+        return 'OFF'
+    }
+
+    return LOG_LEVEL_MAPPING[winstonLogLevel.trim().toLowerCase()] || 'OFF'
 }
 
 function revealConfig() {

--- a/snowflake.js
+++ b/snowflake.js
@@ -72,6 +72,16 @@ function setLogLevel(logLevel) {
     }
 }
 
+function setSnowflakeLogLevel(logLevel) {
+    const validLogLevels = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
+
+    const configuredLogLevel = validLogLevels.includes(logLevel?.toUpperCase()) 
+        ? logLevel.toUpperCase() 
+        : 'ERROR'
+
+    snowflake.configure({ logLevel: configuredLogLevel })
+}
+
 function revealConfig() {
     // if (config.obfuscationEncodingKey != null && config.obfuscationEncodingKey.toString().length > 0) {
     //     for (const [key, value] of Object.entries(config.connection)) {
@@ -165,9 +175,11 @@ function parseOptions() {
 }
 
 function execute() {
-    const parsedOptions = parseOptions(),
-        config = loadNriConfig(parsedOptions),
-        connection = snowflake.createConnection(config.connection)
+    const parsedOptions = parseOptions(), 
+        config = loadNriConfig(parsedOptions)
+    
+    setSnowflakeLogLevel(config.logLevel)
+    const connection = snowflake.createConnection(config.connection)
 
     connection.connect((err, connection) => {
         if (err) {


### PR DESCRIPTION
Hi Devs.

Snowflake log messages appear in NewRelic events, which seems to break their schema. These NR events look something like this:

![image](https://github.com/user-attachments/assets/d3787e0d-4d7e-4e15-abec-5e3f5fb74bc8)


I suggest setting the Snowflake logger's default log level to ERROR to fix this.